### PR TITLE
Refactor and enhance Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,31 @@ sudo: false
 dart:
   - stable
   - dev
-## The dev channel is stable enough, report failures now.
-# env: # important: w/o this top-level env, no job will be allowed to fail.
-# matrix:
+
+env: # important: w/o this top-level env, no job will be allowed to fail.
+  global:
+    - DISPLAY=:99.0
+  matrix:
+    - CI_JOB=tool/travis.sh
+    - CI_JOB=tool/version-check-and-update.sh
+    - CI_JOB=tool/build-check.sh
+    - CI_JOB=tool/web-angular-test.sh
+
+matrix:
+  exclude:
+  - dart: dev
+    env: CI_JOB=tool/version-check-and-update.sh
+  - dart: dev
+    env: CI_JOB=tool/build-check.sh
 #   allow_failures:
+#   ## The dev channel is stable enough, report failures now.
 #   - dart: dev
+
 with_content_shell: true
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-script: ./tool/travis.sh
+
+before_script: sh -e /etc/init.d/xvfb start
+
+script: $CI_JOB
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/tool/build-check.sh
+++ b/tool/build-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Ensure that grind build was run.
+#
+# Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -x -e -o pipefail
+
+dart tool/grind.dart build
+git status
+git add .
+git diff-index --quiet HEAD

--- a/tool/env-set.sh
+++ b/tool/env-set.sh
@@ -1,0 +1,12 @@
+# This bash file is meant to be source'd, not executed.
+
+# Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+if [ ! $(type -t travis_fold) ]; then
+    travis_fold () { echo "travis_fold:${1}:${2}"; }
+    # In case this is being run locally. Turn travis_fold into a noop.
+    # travis_fold () { true; }
+fi
+export -f travis_fold

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -7,12 +7,7 @@
 # Fast fail the script on failures.
 set -e
 
-if [ ! $(type -t travis_fold) ]; then
-    travis_fold () { echo "travis_fold:${1}:${2}"; }
-    # In case this is being run locally. Turn travis_fold into a noop.
-    # travis_fold () { true; }
-fi
-export -f travis_fold
+source ./tool/env-set.sh
 
 # Verify that the libraries are error free.
 dartanalyzer --fatal-warnings \
@@ -41,13 +36,3 @@ if [ "$COVERALLS_TOKEN" ]; then
     test/all.dart
   travis_fold end dart_coveralls
 fi
-
-# Run component tests for web-angular.
-pushd templates/web-angular
-travis_fold start web_angular.pub
-  (set -x; pub get)
-travis_fold end web_angular.pub
-travis_fold start web_angular.test
-  (set -x; pub run angular_test)
-travis_fold end web_angular.test
-popd

--- a/tool/version-check-and-update.sh
+++ b/tool/version-check-and-update.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Ensure that all relevant files have consistent app version numbers.
+#
+# Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -e -o pipefail
+
+EXIT_CODE=0
+
+VERS_FROM_PUB=$(grep '^version:' pubspec.yaml | awk '{ print $2 }')
+
+echo "Version of stagehand from pubspec.yaml: $VERS_FROM_PUB"
+
+CLIFILE=lib/src/cli_app.dart
+if grep -qe "APP_VERSION = '$VERS_FROM_PUB';" $CLIFILE; then
+  echo "✔ $CLIFILE has same version as pubspec."
+else
+  EXIT_CODE=2
+  perl -i -pe "s/(APP_VERSION = ')[^']*(';)/APP_VERSION = '$VERS_FROM_PUB';/" $CLIFILE
+  echo "⚠ $CLIFILE: HAS BEEN MODIFIED to use pubspec app version."
+fi
+
+CHANGELOG=CHANGELOG.md
+VERS_WO_DEV=${VERS_FROM_PUB/%-dev/}
+
+if grep -qe "^##\s*${VERS_WO_DEV//./\\.}\s*" $CHANGELOG; then
+  echo "✔ $CHANGELOG has entry for $VERS_WO_DEV"
+else
+  EXIT_CODE=1
+  echo "❌ $CHANGELOG: Can't find entry for $VERS_WO_DEV"
+fi
+
+exit $EXIT_CODE

--- a/tool/web-angular-test.sh
+++ b/tool/web-angular-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -e -o pipefail
+
+source ./tool/env-set.sh
+
+# Run component tests for web-angular.
+pushd templates/web-angular
+travis_fold start web_angular.pub
+  (set -x; pub get)
+travis_fold end web_angular.pub
+travis_fold start web_angular.test
+  (set -x; pub run angular_test)
+travis_fold end web_angular.test
+popd


### PR DESCRIPTION
- Move web-angular test into its own job. Fixes #424.
- Add an app version consistency check. Fixes #432.
- Add a check that grind was run, as mentioned in #440.
  <br>**Alternative:** instead we could just run grind `build` before deploying and avoid committing the built/generated files.

Note that `tool/version-check-and-update.sh` can be run to update the `lib/src/cli_app.dart` file using the app version in `pubspec.yaml`.

cc @kwalrath 
