### PR TITLE
Fixed: license text is word complete

### DIFF
--- a/templates/web-angular/LICENSE
+++ b/templates/web-angular/LICENSE
@@ -3,6 +3,7 @@ All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -15,7 +16,7 @@ modification, are permitted provided that the following conditions are met:
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
 DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND


### PR DESCRIPTION
Hey [again](https://github.com/dart-lang/site-webdev/pull/1012) Dart team folks!

I noticed while generating a new angular project that the license text seems to have been taken from a template, but is not complete.

I did a bit of research on the interwebs and it shows that the language is either as shown in the diff below, or is the name of the author. 

That leaves us with two main tasks:

 - [ ] agree upon whether to use this text or `__author__` (its a [valid regex](https://github.com/dart-lang/stagehand/blob/master/lib/src/common.dart#L13) that is used in the [first line](https://github.com/dart-lang/stagehand/blob/master/templates/web-angular/LICENSE#L1))
 - [ ] update the other licenses according to the above decision

```
 $ git grep "<COPYRIGHT HOLDER>"
templates/console-full/LICENSE:DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
templates/package-simple/LICENSE:DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
templates/server-shelf/LICENSE:DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
templates/web-simple/LICENSE:DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
templates/web-stagexl/LICENSE:DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
```