### PR TITLE
Update: installation documents to be explicit about checking version

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -64,8 +64,14 @@
       <h1 id="get-started">Get Started</h1>
 
       <p>Installing Stagehand requires the Dart SDK, version 1.6 or greater.
-      Once the Dart SDK is on your path, you can install the stagehand pub
-      package:</p>
+      You can check this by running the following command:</p>
+
+      <pre><code>
+$ dart --version
+      </code></pre>
+
+      <p>Once you confirm that the version of the Dart SDK is recent enough,
+      you can install the stagehand package:</p>
 
       <p>
       <pre><code>


### PR DESCRIPTION
The docs do not specify what it means that the "Dart SDK is on your path".
For someone who knows what this is, it is redundant and for others it may not mean much.

The patch intends to make it a more actionable step, if the command here fails because the Dart SDK is not found, *nix systems will at least complain with a standard `command not found: dart` and this can be debugged independently.