### PR TITLE
chore: rerun grind to generate new copyright year

### DIFF
--- a/lib/generators/console_full_data.dart
+++ b/lib/generators/console_full_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lib/generators/package_simple_data.dart
+++ b/lib/generators/package_simple_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lib/generators/server_shelf_data.dart
+++ b/lib/generators/server_shelf_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lib/generators/web_angular_data.dart
+++ b/lib/generators/web_angular_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lib/generators/web_simple_data.dart
+++ b/lib/generators/web_simple_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/lib/generators/web_stagexl_data.dart
+++ b/lib/generators/web_stagexl_data.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Fixes #460 

Maybe we shouldn't be using the current year in the Copyright notice, but rather the year from the originating file? Anyhow, this is a quick fix to #460.

cc @kevmoo 