### PR TITLE
update to the latest args

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ executables:
   stagehand:
 
 dependencies:
-  args: '>=0.12.0+1 <0.14.0'
+  args: '>=0.12.0+1 <2.0.0'
   http: ^0.11.0
   path: ^1.3.0
   usage: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ executables:
   stagehand:
 
 dependencies:
-  args: '>=0.12.0+1 <2.0.0'
+  args: ^1.0.0
   http: ^0.11.0
   path: ^1.3.0
   usage: ^3.0.0


### PR DESCRIPTION
- `stagehand` specified an older args, and was causing other packages to resolve to a pre-1.0 args