### PR TITLE
upgrades for dart 2

### DIFF
--- a/lib/generators/web_angular.dart
+++ b/lib/generators/web_angular.dart
@@ -17,8 +17,4 @@ class WebAngularGenerator extends DefaultGenerator {
 
     setEntrypoint(getFile('web/index.html'));
   }
-
-  @override
-  String getInstallInstructions() => '${super.getInstallInstructions()}\n'
-      'to run your app, use `pub serve`.';
 }

--- a/test/validate_templates.dart
+++ b/test/validate_templates.dart
@@ -74,6 +74,7 @@ void main() {
 
 void _testGenerator(stagehand.Generator generator, Directory tempDir) {
   Dart.run(path.join(path.current, 'bin/stagehand.dart'),
+      vmArgs: ['--preview-dart-2'],
       arguments: ['--mock-analytics', generator.id],
       runOptions: new RunOptions(workingDirectory: tempDir.path));
 


### PR DESCRIPTION
- make sure that the template generation can work when run in `--preview-dart-2`
- remove some explicit instructions in the  `WebAngularGenerator` template to  run pub serve