### PR TITLE
web-angular test --delete-conflicting-outputs

### DIFF
--- a/tool/web-angular-test.sh
+++ b/tool/web-angular-test.sh
@@ -19,6 +19,6 @@ travis_fold start web_angular.pub
   (set -x; pub get)
 travis_fold end web_angular.pub
 travis_fold start web_angular.test
-  (set -x; pub run build_runner test --fail-on-severe -- -p chrome --reporter=expanded)
+  (set -x; pub run build_runner test --delete-conflicting-outputs --fail-on-severe -- -p chrome --reporter=expanded)
 travis_fold end web_angular.test
 popd


### PR DESCRIPTION
Build is currently broken, https://travis-ci.org/dart-lang/stagehand/jobs/383409929:

> Found 1 declared outputs which already exist on disk. This is likely because the`.dart_tool/build` folder was deleted, or you are submitting generated files to your source repository.
Delete these files?
1 - Delete
2 - Cancel build
3 - List conflicts
No output has been received in the last 10m0s

Hopefully this will fix it.