### PR TITLE
misc: cleanup .gitignore files across templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
   - Updated dependencies:
     - `-alpha+15` versions of `angular` and `angular_components`.
     - `build_runner ^0.9.0`
-- All templates: upgrade `test` to `^1.0.0`.
+- All templates:
+  - Upgrade `test` to `^1.0.0`.
+  - Update default `.gitignore`.
 
 ## 3.0.0
 

--- a/lib/src/generators/console_full.g.dart
+++ b/lib/src/generators/console_full.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/lib/src/generators/package_simple.g.dart
+++ b/lib/src/generators/package_simple.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/lib/src/generators/server_shelf.g.dart
+++ b/lib/src/generators/server_shelf.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/lib/src/generators/web_angular.g.dart
+++ b/lib/src/generators/web_angular.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/lib/src/generators/web_simple.g.dart
+++ b/lib/src/generators/web_simple.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/lib/src/generators/web_stagexl.g.dart
+++ b/lib/src/generators/web_stagexl.g.dart
@@ -15,9 +15,10 @@ const _data = const <String>[
   'text',
   '''
 IyBGaWxlcyBhbmQgZGlyZWN0b3JpZXMgY3JlYXRlZCBieSBwdWIKLmRhcnRfdG9vbC8KLnBhY2th
-Z2VzCi5wdWIvCmJ1aWxkLwojIFJlbW92ZSB0aGUgZm9sbG93aW5nIHBhdHRlcm4gaWYgeW91IHdp
-c2ggdG8gY2hlY2sgaW4geW91ciBsb2NrIGZpbGUKcHVic3BlYy5sb2NrCgojIERpcmVjdG9yeSBj
-cmVhdGVkIGJ5IGRhcnRkb2MKZG9jL2FwaS8K''',
+Z2VzCiMgUmVtb3ZlIHRoZSBmb2xsb3dpbmcgcGF0dGVybiBpZiB5b3Ugd2lzaCB0byBjaGVjayBp
+biB5b3VyIGxvY2sgZmlsZQpwdWJzcGVjLmxvY2sKCiMgQ29udmVudGlvbmFsIGRpcmVjdG9yeSBm
+b3IgYnVpbGQgb3V0cHV0cwpidWlsZC8KCiMgRGlyZWN0b3J5IGNyZWF0ZWQgYnkgZGFydGRvYwpk
+b2MvYXBpLwo=''',
   'CHANGELOG.md',
   'text',
   'IyMgMS4wLjAKCi0gSW5pdGlhbCB2ZXJzaW9uLCBjcmVhdGVkIGJ5IFN0YWdlaGFuZAo=',

--- a/templates/console-full/.gitignore
+++ b/templates/console-full/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/templates/package-simple/.gitignore
+++ b/templates/package-simple/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/templates/server-shelf/.gitignore
+++ b/templates/server-shelf/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/templates/web-angular/.gitignore
+++ b/templates/web-angular/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/templates/web-simple/.gitignore
+++ b/templates/web-simple/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/

--- a/templates/web-stagexl/.gitignore
+++ b/templates/web-stagexl/.gitignore
@@ -1,10 +1,11 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
-.pub/
-build/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
+
+# Conventional directory for build outputs
+build/
 
 # Directory created by dartdoc
 doc/api/


### PR DESCRIPTION
Dart 2 does not create a .pub directory
`build/` is not created by pub – move it to a new section