### PR TITLE
Add categories to --machine output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.3.0-dev
 
+- Include templates `categories` in the `--machine` output.
+
 ## 3.2.1
 
 - All templates:

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -234,7 +234,8 @@ additional analytics to help us improve Stagehand [y/yes/no]?''');
       var m = {
         'name': generator.id,
         'label': generator.label,
-        'description': generator.description
+        'description': generator.description,
+        'categories': generator.categories
       };
 
       if (generator.entrypoint != null) {

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -60,11 +60,26 @@ void main() {
       return _expectError(app.process(['consoleapp', 'foobar']));
     });
 
-    test('machine format', () {
-      return app.process(['--machine']).then((_) {
+    group('machine format', () {
+      test('returns a list of results', () async {
+        await app.process(['--machine']);
         _expectOk();
         List results = jsonDecode(logger.getStdout());
-        expect(results, isNot(isEmpty));
+        expect(results, isNotEmpty);
+      });
+
+      test('includes categories', () async {
+        await app.process(['--machine']);
+        _expectOk();
+        List results = jsonDecode(logger.getStdout());
+
+        var consoleFull =
+            results.singleWhere((item) => item['name'] == 'console-full');
+        expect(consoleFull, isNotNull);
+        expect(
+          consoleFull['categories'],
+          allOf(isNotNull, isList, contains('dart'), contains('console')),
+        );
       });
     });
 


### PR DESCRIPTION
This adds the (existing) categories to the JSON output so that editors can filter them.

LMK if I should bump the version/add to changelog here (or include this in the other PR elsewhere..).

@kevmoo @devoncarew FYI!