### PR TITLE
Remove xvfb from web-angular-test.sh

### DIFF
--- a/tool/web-angular-test.sh
+++ b/tool/web-angular-test.sh
@@ -12,9 +12,6 @@ source ./tool/env-set.sh
 # Run component tests for web-angular.
 pushd templates/web-angular
 
-sh -e /etc/init.d/xvfb start
-t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done
-
 travis_fold start web_angular.pub
   (set -x; pub get)
 travis_fold end web_angular.pub


### PR DESCRIPTION
I don't think xvfb is required to run chrome tests anymore, but here goes...