### PR TITLE
don't collapse version.dart in github code reviews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * -text
+
+# Don't collapse in github code reviews by default.
+lib/src/version.dart linguist-generated=false


### PR DESCRIPTION
- don't collapse version.dart in github code reviews

@kwalrath 

See https://github.com/dart-lang/stagehand/pull/648/files for an example.