### PR TITLE
recommend the `any` constraint for package:test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.8-dev
+
+- Changed the dev dependency for new projects for package:test to `any`.
+
 ## 3.3.7
 
 - Added a new template: `console-simple`.

--- a/lib/src/generators/console_full.g.dart
+++ b/lib/src/generators/console_full.g.dart
@@ -53,7 +53,7 @@ bmFtZTogX19wcm9qZWN0TmFtZV9fCmRlc2NyaXB0aW9uOiBBIHNhbXBsZSBjb21tYW5kLWxpbmUg
 YXBwbGljYXRpb24uCiMgdmVyc2lvbjogMS4wLjAKIyBob21lcGFnZTogaHR0cHM6Ly93d3cuZXhh
 bXBsZS5jb20KCmVudmlyb25tZW50OgogIHNkazogJz49Mi43LjAgPDMuMC4wJwoKI2RlcGVuZGVu
 Y2llczoKIyAgcGF0aDogXjEuNi4wCgpkZXZfZGVwZW5kZW5jaWVzOgogIHBlZGFudGljOiBeMS44
-LjAKICB0ZXN0OiBeMS42LjAK''',
+LjAKICB0ZXN0OiBhbnkK''',
   'test/__projectName___test.dart',
   'text',
   '''

--- a/lib/src/generators/package_simple.g.dart
+++ b/lib/src/generators/package_simple.g.dart
@@ -67,7 +67,7 @@ bmFtZTogX19wcm9qZWN0TmFtZV9fCmRlc2NyaXB0aW9uOiBBIHN0YXJ0aW5nIHBvaW50IGZvciBE
 YXJ0IGxpYnJhcmllcyBvciBhcHBsaWNhdGlvbnMuCiMgdmVyc2lvbjogMS4wLjAKIyBob21lcGFn
 ZTogaHR0cHM6Ly93d3cuZXhhbXBsZS5jb20KCmVudmlyb25tZW50OgogIHNkazogJz49Mi43LjAg
 PDMuMC4wJwoKI2RlcGVuZGVuY2llczoKIyAgcGF0aDogXjEuNi4wCgpkZXZfZGVwZW5kZW5jaWVz
-OgogIHBlZGFudGljOiBeMS44LjAKICB0ZXN0OiBeMS42LjAK''',
+OgogIHBlZGFudGljOiBeMS44LjAKICB0ZXN0OiBhbnkK''',
   'test/__projectName___test.dart',
   'text',
   '''

--- a/lib/src/generators/web_angular.g.dart
+++ b/lib/src/generators/web_angular.g.dart
@@ -126,7 +126,7 @@ L3d3dy5leGFtcGxlLmNvbQoKZW52aXJvbm1lbnQ6CiAgc2RrOiAnPj0yLjcuMCA8My4wLjAnCgpk
 ZXBlbmRlbmNpZXM6CiAgYW5ndWxhcjogXjUuMy4wCiAgYW5ndWxhcl9jb21wb25lbnRzOiBeMC4x
 My4wCgpkZXZfZGVwZW5kZW5jaWVzOgogIGFuZ3VsYXJfdGVzdDogXjIuMy4wCiAgYnVpbGRfcnVu
 bmVyOiBeMS42LjAKICBidWlsZF90ZXN0OiBeMC4xMC44CiAgYnVpbGRfd2ViX2NvbXBpbGVyczog
-XjIuMy4wCiAgcGVkYW50aWM6IF4xLjguMAogIHRlc3Q6IF4xLjYuMAo=''',
+XjIuMy4wCiAgcGVkYW50aWM6IF4xLjguMAogIHRlc3Q6IGFueQo=''',
   'test/app_test.dart',
   'text',
   '''

--- a/templates/console-full/pubspec.yaml
+++ b/templates/console-full/pubspec.yaml
@@ -11,4 +11,4 @@ environment:
 
 dev_dependencies:
   pedantic: ^1.8.0
-  test: ^1.6.0
+  test: any

--- a/templates/package-simple/pubspec.yaml
+++ b/templates/package-simple/pubspec.yaml
@@ -11,4 +11,4 @@ environment:
 
 dev_dependencies:
   pedantic: ^1.8.0
-  test: ^1.6.0
+  test: any

--- a/templates/web-angular/pubspec.yaml
+++ b/templates/web-angular/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
   build_test: ^0.10.8
   build_web_compilers: ^2.3.0
   pedantic: ^1.8.0
-  test: ^1.6.0
+  test: any


### PR DESCRIPTION
- recommend the `any` constraint for package:test

This aligns with the new guidance from the `dartdev create` command. It also means that our version recommendation won't get out of date.

