### PR TITLE
project name must be normalized on generation

### DIFF
--- a/lib/stagehand.dart
+++ b/lib/stagehand.dart
@@ -96,7 +96,7 @@ abstract class Generator implements Comparable<Generator> {
     Map<String, String> additionalVars,
   }) {
     final vars = {
-      'projectName': projectName,
+      'projectName': normalizeProjectName(projectName),
       'description': description,
       'year': DateTime.now().year.toString(),
       'author': '<your name>',


### PR DESCRIPTION
TL;DR:

project name on `dart create <project-name>` must be normalized otherwise it fails while `pub get`.

## Steps:

Try to install dart project using `dart create` CLI helper.

```
$ dart create some-project
Creating /tmp/some-project using template console-simple...

  .gitignore
  CHANGELOG.md
  README.md
  analysis_options.yaml
  bin/some-project.dart
  pubspec.yaml

Running pub get...
Error on line 1, column 7 of pubspec.yaml: "name" field must be a valid Dart identifier.
  ╷
1 │ name: some-project
  │       ^^^
  ╵
```

## Expected:

It should be normalized to `some_project` but it keeps as input and throws while `pub get`.

## Actual:

Throws 

```
Running pub get...
Error on line 1, column 7 of pubspec.yaml: "name" field must be a valid Dart identifier.
  ╷
1 │ name: some-project
  │       ^^^
  ╵
```

## The issue:

Normalization is not done on neither `commands/create.dart` nor here. It should be done here anyway. (ref: https://github.com/dart-lang/sdk/blob/master/pkg/dartdev/lib/src/commands/create.dart#L95-L98)