### PR TITLE
Disable null safety and prepare for beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.0.0
+## 4.0.0-beta.1
 
-- Enable null safety by default (min SDK constraint is 2.12)
+- Enable null safety by default (min SDK constraint is 2.12).
+  This will be released as a stable version with the next stable Dart SDK.
 
 ## 3.3.12-dev
 

--- a/bin/stagehand.dart
+++ b/bin/stagehand.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:io' as io;
 

--- a/lib/src/cli_app.dart
+++ b/lib/src/cli_app.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Some utility methods for stagehand.
 import 'dart:convert' show base64, utf8;
 

--- a/lib/src/generators/console_full.dart
+++ b/lib/src/generators/console_full.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'console_full.g.dart';

--- a/lib/src/generators/console_full.g.dart
+++ b/lib/src/generators/console_full.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'console_full.dart';
 
 // **************************************************************************

--- a/lib/src/generators/console_simple.dart
+++ b/lib/src/generators/console_simple.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'console_simple.g.dart';

--- a/lib/src/generators/console_simple.g.dart
+++ b/lib/src/generators/console_simple.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'console_simple.dart';
 
 // **************************************************************************

--- a/lib/src/generators/package_simple.dart
+++ b/lib/src/generators/package_simple.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'package_simple.g.dart';

--- a/lib/src/generators/package_simple.g.dart
+++ b/lib/src/generators/package_simple.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'package_simple.dart';
 
 // **************************************************************************

--- a/lib/src/generators/server_shelf.dart
+++ b/lib/src/generators/server_shelf.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'server_shelf.g.dart';

--- a/lib/src/generators/server_shelf.g.dart
+++ b/lib/src/generators/server_shelf.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'server_shelf.dart';
 
 // **************************************************************************

--- a/lib/src/generators/web_angular.dart
+++ b/lib/src/generators/web_angular.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'web_angular.g.dart';

--- a/lib/src/generators/web_angular.g.dart
+++ b/lib/src/generators/web_angular.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'web_angular.dart';
 
 // **************************************************************************

--- a/lib/src/generators/web_simple.dart
+++ b/lib/src/generators/web_simple.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'web_simple.g.dart';

--- a/lib/src/generators/web_simple.g.dart
+++ b/lib/src/generators/web_simple.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'web_simple.dart';
 
 // **************************************************************************

--- a/lib/src/generators/web_stagexl.dart
+++ b/lib/src/generators/web_stagexl.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import '../common.dart';
 
 part 'web_stagexl.g.dart';

--- a/lib/src/generators/web_stagexl.g.dart
+++ b/lib/src/generators/web_stagexl.g.dart
@@ -1,5 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// @dart=2.9
 part of 'web_stagexl.dart';
 
 // **************************************************************************

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0';
+const packageVersion = '4.0.0-beta.1';

--- a/lib/stagehand.dart
+++ b/lib/stagehand.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 /// Stagehand is a Dart project generator.
 ///
 /// Stagehand helps you get your Dart projects set up and ready for the big

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   # https://github.com/dart-lang/stagehand/issues/617
   #
   # Also make sure this minimum sdk version is reflected in `.travis.yml`.
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 # Add the bin/stagehand.dart script to the scripts pub installs.
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
   A scaffolding generator for your Dart projects. Stagehand helps you get set
   up!
 # After changing the version, run `pub run build_runner build`.
-version: 4.0.0
+version: 4.0.0-beta.1
 homepage: https://github.com/dart-lang/stagehand
 
 environment:

--- a/test/all.dart
+++ b/test/all.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'cli_test.dart' as cli_test;
 import 'common_test.dart' as common_test;
 import 'generators_test.dart' as generators_test;

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2014, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// @dart=2.9
+
 @TestOn('vm')
 import 'dart:async';
 import 'dart:convert';

--- a/test/common_test.dart
+++ b/test/common_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:stagehand/src/common.dart';
 import 'package:test/test.dart';
 

--- a/test/generators_test.dart
+++ b/test/generators_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:stagehand/stagehand.dart';
 import 'package:test/test.dart';
 

--- a/test/mock_test.dart
+++ b/test/mock_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 

--- a/test/validate_templates.dart
+++ b/test/validate_templates.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 // This is explicitly not named with _test.dart extension so it is not run as
 // part of the normal test process
 @TestOn('vm')

--- a/tool/builder.dart
+++ b/tool/builder.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:source_gen/source_gen.dart';
 import 'package:build/build.dart';
 

--- a/tool/src/code_generator.dart
+++ b/tool/src/code_generator.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;


### PR DESCRIPTION
Prepare for a beta release of 4.0.0 (that enables null safety by default). Per @devoncarew we don't want to publish this as a stable version before the next stable SDK, as that would cause some to get it prematurely.