### PR TITLE
Https links

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,7 @@ analyzer:
   exclude:
     - 'templates/**'
 
-      # Lint rules and documentation, see https://dart-lang.github.io/linter/lints
+# Lint rules and documentation, see https://dart-lang.github.io/linter/lints
   errors:
     unused_element: error
     unused_import: error

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,7 @@ analyzer:
   exclude:
     - 'templates/**'
 
-# Lint rules and documentation, see http://dart-lang.github.io/linter/lints
+      # Lint rules and documentation, see https://dart-lang.github.io/linter/lints
   errors:
     unused_element: error
     unused_import: error

--- a/templates/analysis_options.yaml
+++ b/templates/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/console-full/analysis_options.yaml
+++ b/templates/console-full/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/console-simple/analysis_options.yaml
+++ b/templates/console-simple/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/package-simple/analysis_options.yaml
+++ b/templates/package-simple/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/server-shelf/analysis_options.yaml
+++ b/templates/server-shelf/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/web-angular/analysis_options.yaml
+++ b/templates/web-angular/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/web-simple/analysis_options.yaml
+++ b/templates/web-simple/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:

--- a/templates/web-stagexl/analysis_options.yaml
+++ b/templates/web-stagexl/analysis_options.yaml
@@ -3,7 +3,7 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# For lint rules and documentation, see https://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 # linter:
 #   rules:


### PR DESCRIPTION
Changed all http://dart-lang.github.io/linter/lints links to their https counterparts